### PR TITLE
update ForeignTopLevel on null window focus

### DIFF
--- a/src/protocols/ForeignToplevelWlr.cpp
+++ b/src/protocols/ForeignToplevelWlr.cpp
@@ -347,9 +347,6 @@ CForeignToplevelWlrProtocol::CForeignToplevelWlrProtocol(const wl_interface* ifa
     static auto P3 = g_pHookSystem->hookDynamic("activeWindow", [this](void* self, SCallbackInfo& info, std::any data) {
         const auto PWINDOW = std::any_cast<PHLWINDOW>(data);
 
-        if (!windowValidForForeign(PWINDOW))
-            return;
-
         for (auto const& m : m_vManagers) {
             m->onNewFocus(PWINDOW);
         }


### PR DESCRIPTION
removes check for valid window so ForeignTopLevel gets updated on null window focus
don't see any crashes or side effects, but haven't checked if everything is properly handled in `onNewFocus`